### PR TITLE
add translation command / add utils for reusable logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project is using https://github.com/spf13/cobra as a foundation.
 |----------|----------------|---------------------------------------------------------|
 | question | `--local`/`-l`       | Ask a question to generate text based on the input.     |
 | image    | n/a    | Create an image from a prompt using the OpenAI API and DALLE<X> model |
+| translate | `--local`/`-l`    | Translate a sentence or word from one language to another |
 
 ## Prerequisites
 - Azure account

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -16,10 +16,10 @@ import (
 )
 
 // exampleCmd represents the example command
-var questionCmd = &cobra.Command{
-	Use:   "question",
-	Short: "ask the LLM a question",
-	Long:  `use this command to ask a generic question and get an answer in your terminal`,
+var translateCmd = &cobra.Command{
+	Use:   "translate",
+	Short: "ask the LLM to translate a sentence",
+	Long:  `use this command to ask the LLM to translate a sentence from one language to another`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// Load the .env file
@@ -38,10 +38,16 @@ var questionCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			question := GetUserInput("Please enter your question: ")
+			languageA := GetUserInput("Please enter the language you want to translate from: ")
+
+			languageB := GetUserInput("Please enter the language you want to translate to: ")
+
+			sentence := GetUserInput("Please enter the sentence or word you want to translate: ")
+
+			prompt := "You are a professional translator and multi-linguist. You are to strictly only answer language translation questions from the user. You must now translate the following sentence from " + languageA + " to " + languageB + ": " + sentence
 
 			ctx := context.Background()
-			completion, err := llms.GenerateFromSinglePrompt(ctx, llm, question)
+			completion, err := llms.GenerateFromSinglePrompt(ctx, llm, prompt)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -63,8 +69,13 @@ var questionCmd = &cobra.Command{
 
 			keyCredential := azcore.NewKeyCredential(azureOpenAIKey)
 
-			// Get question from user input
-			question := GetUserInput("Please enter your question: ")
+			languageA := GetUserInput("Please enter the language you want to translate from: ")
+
+			languageB := GetUserInput("Please enter the language you want to translate to: ")
+
+			sentence := GetUserInput("Please enter the sentence or word you want to translate: ")
+
+			prompt := "You must now translate the following sentence from " + languageA + " to " + languageB + ": " + sentence
 
 			client, err := azopenai.NewClientWithKeyCredential(azureOpenAIEndpoint, keyCredential, nil)
 
@@ -77,11 +88,11 @@ var questionCmd = &cobra.Command{
 			// NOTE: all messages, regardless of role, count against token usage for this API.
 			messages := []azopenai.ChatRequestMessageClassification{
 				// You set the tone and rules of the conversation with a prompt as the system role.
-				&azopenai.ChatRequestSystemMessage{Content: to.Ptr("You are a personal assistant to help with generic user questions. You can provide information on a wide range of topics.")},
+				&azopenai.ChatRequestSystemMessage{Content: to.Ptr("You are a professional translator and multi-linguist. You are to strictly only answer language translation questions from the user.")},
 
 				// The user asks a question
 				// &azopenai.ChatRequestUserMessage{Content: azopenai.NewChatRequestUserMessageContent("Does Azure OpenAI support customer managed keys?")},
-				&azopenai.ChatRequestUserMessage{Content: azopenai.NewChatRequestUserMessageContent(question)},
+				&azopenai.ChatRequestUserMessage{Content: azopenai.NewChatRequestUserMessageContent(prompt)},
 
 				// The reply would come back from the model. You'd add it to the conversation so we can maintain context.
 				// &azopenai.ChatRequestAssistantMessage{Content: to.Ptr("Yes, customer managed keys are supported by Azure OpenAI")},
@@ -141,10 +152,10 @@ var questionCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(questionCmd)
+	rootCmd.AddCommand(translateCmd)
 
-	// Add local flag to question command
-	questionCmd.Flags().BoolP("local", "l", false, "Use local model")
+	// Add local flag to translate command
+	translateCmd.Flags().BoolP("local", "l", false, "Use local model")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -8,7 +8,6 @@ import (
 
 func GetUserInput(userPrint string) string {
 	reader := bufio.NewReader(os.Stdin)
-	// fmt.Print("I am a generic helper. I may or may not know the answer to your question so be patient with me. \nPlease enter your question: ")
 	fmt.Print(userPrint)
 	userInput, _ := reader.ReadString('\n')
 	return userInput

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func GetUserInput(userPrint string) string {
+	reader := bufio.NewReader(os.Stdin)
+	// fmt.Print("I am a generic helper. I may or may not know the answer to your question so be patient with me. \nPlease enter your question: ")
+	fmt.Print(userPrint)
+	userInput, _ := reader.ReadString('\n')
+	return userInput
+}


### PR DESCRIPTION
This pull request introduces a new translation functionality to the project and refactors the way user input is gathered. The most significant changes are the addition of a new `translate` command, the refactoring of the `getUserInput()` function, and the update to the `README.md` file.

New functionality:

* [`cmd/translate.go`](diffhunk://#diff-3fb22a9427ca68ab46831d291e26ca0ae21c37ab860b335488b9748944cd0bcdR1-R169): A new command `translate` has been added. This command prompts the user to input the languages they want to translate from and to, as well as the sentence or word they want to translate. It then uses either a local or online language model to generate a translation.

Refactoring:

* [`cmd/question.go`](diffhunk://#diff-17fb2a7d40eb92258575e7f76480d1ce07dcc74180622987762e9758bc4f38afL4): The `getUserInput()` function has been replaced with the `GetUserInput()` function, which takes an input prompt as a parameter. This change is reflected in the `questionCmd` command. [[1]](diffhunk://#diff-17fb2a7d40eb92258575e7f76480d1ce07dcc74180622987762e9758bc4f38afL4) [[2]](diffhunk://#diff-17fb2a7d40eb92258575e7f76480d1ce07dcc74180622987762e9758bc4f38afL42-R41) [[3]](diffhunk://#diff-17fb2a7d40eb92258575e7f76480d1ce07dcc74180622987762e9758bc4f38afL68-R67) [[4]](diffhunk://#diff-17fb2a7d40eb92258575e7f76480d1ce07dcc74180622987762e9758bc4f38afL144-L150)
* [`cmd/utils.go`](diffhunk://#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160R1-R15): The `GetUserInput()` function has been moved to a new file `utils.go` to make it reusable across different commands.

Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12): The `README.md` file has been updated to include the new `translate` command in the list of available commands.