### PR TITLE
download AI generated images using the --download flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is using https://github.com/spf13/cobra as a foundation.
 | Command  | Flag(s)           | Description                                             |
 |----------|----------------|---------------------------------------------------------|
 | question | `--local`/`-l`       | Ask a question to generate text based on the input.     |
-| image    | n/a    | Create an image from a prompt using the OpenAI API and DALLE<X> model |
+| image    | `--download`/`-d`    | Create an image from a prompt using the OpenAI API and DALLE<X> model |
 | translate | `--local`/`-l`    | Translate a sentence or word from one language to another |
 
 ## Prerequisites


### PR DESCRIPTION
This pull request includes several changes to enhance the image creation command and improve code clarity. The most important changes include adding a download feature for images, renaming a variable for consistency, and updating the README to reflect the new functionality.

Enhancements to image creation command:

* [`cmd/create-image.go`](diffhunk://#diff-b4ca1a2055cab71f8bcd936841192961cce9920779bd74e7d86998c0495054dfL65-R103): Added a new `--download`/`-d` flag to enable downloading generated images to the local device. This includes making HTTP GET requests to retrieve the image and saving it to a temporary file.

Code clarity improvements:

* [`cmd/create-image.go`](diffhunk://#diff-b4ca1a2055cab71f8bcd936841192961cce9920779bd74e7d86998c0495054dfL18-R19): Renamed the `image` variable to `imageCmd` for better consistency with naming conventions.
* [`cmd/create-image.go`](diffhunk://#diff-b4ca1a2055cab71f8bcd936841192961cce9920779bd74e7d86998c0495054dfR7): Added the `io` package to the imports to support the new download functionality.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11): Updated the description of the `image` command to include the new `--download`/`-d` flag.